### PR TITLE
C spells, and minor text changes throughout

### DIFF
--- a/spells.json
+++ b/spells.json
@@ -119,7 +119,7 @@
       },
       {
         "type": "text",
-        "text": "The beast must succeed on a Wisdom saving throw or be charmed by you for the spell's duration.  If you or one of your companions harms the target, the spell ends."
+        "text": "The beast must succeed on a Wisdom saving throw or be charmed by you for the spell's duration. If you or one of your companions harms the target, the spell ends."
       }
     ]
   },
@@ -346,7 +346,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in that area must make a Strength saving throw.  On a failed save, a target takes 2d6 necrotic damage and can't take reactions until its next turn.  On a successful save, the creature takes half damage, but suffers no other effect."
+        "text": "Each creature in that area must make a Strength saving throw. On a failed save, a target takes 2d6 necrotic damage and can't take reactions until its next turn. On a successful save, the creature takes half damage, but suffers no other effect."
       }
     ]
   },
@@ -449,7 +449,7 @@
       },
       {
         "type": "text",
-        "text": "Up to three creatures of your choice that you can see within range must make Charisma saving throws.  Whenever a target that fails this saving throw makes an attack roll or a saving throw before the spell ends, the target must roll a d4 and subtract the number rolled from the attack roll or saving throw."
+        "text": "Up to three creatures of your choice that you can see within range must make Charisma saving throws. Whenever a target that fails this saving throw makes an attack roll or a saving throw before the spell ends, the target must roll a d4 and subtract the number rolled from the attack roll or saving throw."
       }
     ]
   },
@@ -626,7 +626,7 @@
       },
       {
         "type": "text",
-        "text": "You touch a creature, and that creature must succeed on a Wisdom saving throw or become cursed for the duration of the spell.  When you cast this spell, choose the nature of the curse."
+        "text": "You touch a creature, and that creature must succeed on a Wisdom saving throw or become cursed for the duration of the spell. When you cast this spell, choose the nature of the curse."
       }
     ]
   },
@@ -796,7 +796,7 @@
       },
       {
         "type": "text",
-        "text": "The target must make a Constitution saving throw.  The target takes 8d8 necrotic damage on a failed save, or half as much damage on a successful one.  This spell has no effect on undead or constructs.\n\nIf you target a plant creature or a magical plant, it makes the saving throw with disadvantage, and the spell deals maximum damage to it."
+        "text": "The target must make a Constitution saving throw. The target takes 8d8 necrotic damage on a failed save, or half as much damage on a successful one. This spell has no effect on undead or constructs.\n\nIf you target a plant creature or a magical plant, it makes the saving throw with disadvantage, and the spell deals maximum damage to it."
       }
     ]
   },
@@ -868,7 +868,7 @@
       },
       {
         "type": "text",
-        "text": "Choose one creature that you can see within range to make a Constitution saving throw.  If it fails, the target is either blinded or deafened (your choice) for the duration.  At the end of each of its turns, the target can make a Constitution saving throw.\nAt the end of each of its turns, the target can make a Constitution saving throw.  On a success, the spell ends."
+        "text": "Choose one creature that you can see within range to make a Constitution saving throw. If it fails, the target is either blinded or deafened (your choice) for the duration. At the end of each of its turns, the target can make a Constitution saving throw.\nAt the end of each of its turns, the target can make a Constitution saving throw. On a success, the spell ends."
       }
     ]
   },
@@ -1069,7 +1069,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature within 5 feet of the target point must make a Dexterity saving throw.  A creature takes 3d10 lightning damage on a failed save, or half as much damage on a successful one.  On each of your turns until the spell ends, you can use your action to call down lightning in this way again, targeting the same point or a different one."
+        "text": "Each creature within 5 feet of the target point must make a Dexterity saving throw. A creature takes 3d10 lightning damage on a failed save, or half as much damage on a successful one. On each of your turns until the spell ends, you can use your action to call down lightning in this way again, targeting the same point or a different one."
       }
     ]
   },
@@ -1083,14 +1083,33 @@
           {
             "type": "save",
             "stat": "cha",
-            "fail": [],
+            "fail": [
+              {
+                "type": "ieffect",
+                "name": "Calm Emotions",
+                "duration": 10,
+                "effects": ""
+              }
+            ],
             "success": []
           }
         ]
       },
       {
+        "type": "target",
+        "target": "self",
+        "effects": [
+          {
+            "type": "ieffect",
+            "name": "Calm Emotions [Concentration]",
+            "duration": 10,
+            "effects": ""
+          }
+        ]
+      },
+      {
         "type": "text",
-        "text": "Each humanoid in a 20-foot-radius sphere centered on a point you choose within range must make a Charisma saving throw a creature can choose to fail this saving throw if it wishes.  If a creature fails its saving throw, choose one of the following two effects."
+        "text": "Each humanoid in a 20-foot-radius sphere centered on a point you choose within range must make a Charisma saving throw a creature can choose to fail this saving throw if it wishes. If a creature fails its saving throw, choose one of the following two effects."
       }
     ]
   },
@@ -1122,14 +1141,13 @@
           {
             "type": "roll",
             "dice": "10d8[lightning]",
-            "name": "damage",
-            "higher": {}
+            "name": "damage"
           }
         ]
       },
       {
         "type": "text",
-        "text": ""
+        "text": "You create a bolt of lightning that arcs toward a target of your choice that you can see within range. Three bolts then leap from that target to as many as three other targets, each of which must be within 30 feet of the first target. A target can be a creature or an object and can be targeted by only one of the bolts.\n\nA target must make a Dexterity saving throw. The target takes 10d8 lightning damage on a failed save, or half as much damage on a successful one."
       }
     ]
   },
@@ -1143,14 +1161,21 @@
           {
             "type": "save",
             "stat": "wis",
-            "fail": [],
+            "fail": [
+              {
+                "type": "ieffect",
+                "name": "Charm Person - Charmed",
+                "duration": -1,
+                "effects": ""
+              }
+            ],
             "success": []
           }
         ]
       },
       {
         "type": "text",
-        "text": "It must make a Wisdom saving throw, and does so with advantage if you or your companions are fighting it.  If it fails the saving throw, it is charmed by you until the spell ends or until you or your companions do anything harmful to it.  The charmed creature regards you as a friendly acquaintance."
+        "text": "It must make a Wisdom saving throw, and does so with advantage if you or your companions are fighting it. If it fails the saving throw, it is charmed by you until the spell ends or until you or your companions do anything harmful to it. The charmed creature regards you as a friendly acquaintance.\n\nWhen the spell ends, the creature knows it was charmed by you."
       }
     ]
   },
@@ -1167,8 +1192,13 @@
               {
                 "type": "damage",
                 "damage": "1d8[necrotic]",
-                "higher": {},
                 "cantripScale": true
+              },
+              {
+                "type": "ieffect",
+                "name": "Chill Touch - Cannot gain HP",
+                "duration": -1,
+                "effects": ""
               }
             ],
             "miss": []
@@ -1177,7 +1207,7 @@
       },
       {
         "type": "text",
-        "text": "Make a ranged spell attack against the creature to assail it with the chill of the grave.  On a hit, the target takes 1d8 necrotic damage, and it can't regain hit points until the start of your next turn.  Until then, the hand clings to the target."
+        "text": "Make a ranged spell attack against the creature to assail it with the chill of the grave. On a hit, the target takes 1d8 necrotic damage, and it can't regain hit points until the start of your next turn. Until then, the hand clings to the target."
       }
     ]
   },
@@ -1255,17 +1285,47 @@
       },
       {
         "type": "text",
-        "text": "Each creature in that area must make a Constitution saving throw.  A target takes 8d6 necrotic damage on a failed save, or half as much damage on a successful one."
+        "text": "A sphere of negative energy ripples out in a 60-foot-radius sphere from a point within range. Each creature in that area must make a Constitution saving throw. A target takes 8d6 necrotic damage on a failed save, or half as much damage on a successful one."
       }
     ]
   },
   {
     "name": "Circle of Power",
-    "automation": null
+    "automation": [
+      {
+        "type": "target",
+        "target": "self",
+        "effects": [
+          {
+            "type": "ieffect",
+            "name": "Circle of Power [Concentration]",
+            "duration": -1,
+            "effects": ""
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": "Until the spell ends, the sphere moves with you, centered on you. For the duration, each friendly creature in the area (including you) has advantage on saving throws against spells and other magical effects. Additionally, when an affected creature succeeds on a saving throw made against a spell or magical effect that allows it to make a saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw."
+      }
+    ]
   },
   {
     "name": "Clairvoyance",
-    "automation": null
+    "automation": [
+      {
+        "type": "target",
+        "target": "self",
+        "effects": [
+          {
+            "type": "ieffect",
+            "name": "Clairvoyance [Concentration]",
+            "duration": -1,
+            "effects": ""
+          }
+        ]
+      }
+    ]
   },
   {
     "name": "Clone",
@@ -1273,7 +1333,43 @@
   },
   {
     "name": "Cloud of Daggers",
-    "automation": null
+    "automation": [
+      {
+        "type": "target",
+        "target": "all",
+        "effects": [
+          {
+            "type": "damage",
+            "damage": "4d4[slashing]",
+            "higher":{
+              "3": "2d4[slashing]",
+              "4": "4d4[slashing]",
+              "5": "6d4[slashing]",
+              "6": "8d4[slashing]",
+              "7": "10d4[slashing]",
+              "8": "12d4[slashing]",
+              "9": "14d4[slashing]"
+            }
+          }
+        ]
+      },
+      {
+        "type": "target",
+        "target": "self",
+        "effects": [
+          {
+            "type": "ieffect",
+            "name": "Cloud of Daggers [Concentration]",
+            "duration": 10,
+            "effects": ""
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": "You fill the air with spinning daggers in a cube 5 feet on each side, centered on a point you choose within range. A creature takes 4d4 slashing damage when it enters the spell's area for the first time on a turn or starts its turn there."
+      }
+    ]
   },
   {
     "name": "Cloudkill",
@@ -1314,8 +1410,20 @@
         ]
       },
       {
+        "type": "target",
+        "target": "self",
+        "effects": [
+          {
+            "type": "ieffect",
+            "name": "Cloudkill [Concentration]",
+            "duration": -1,
+            "effects": ""
+          }
+        ]
+      },
+      {
         "type": "text",
-        "text": ""
+        "text": "When a creature enters the spell's area for the first time on a turn or starts its turn there, that creature must make a Constitution saving throw. The creature takes 5d8 poison damage on a failed save, or half as much damage on a successful one. Creatures are affected even if they hold their breath or don't need to breathe."
       }
     ]
   },
@@ -1333,14 +1441,21 @@
           {
             "type": "save",
             "stat": "wis",
-            "fail": [],
+            "fail": [
+              {
+                "type": "ieffect",
+                "name": "Command",
+                "duration": 1,
+                "effects": ""
+              }
+            ],
             "success": []
           }
         ]
       },
       {
         "type": "text",
-        "text": "The target must succeed on a Wisdom saving throw or follow the command on its next turn.  The spell has no effect if the target is undead, if it doesn't understand your language, or if your command is directly harmful to it."
+        "text": "The target must succeed on a Wisdom saving throw or follow the command on its next turn. The spell has no effect if the target is undead, if it doesn't understand your language, or if your command is directly harmful to it."
       }
     ]
   },
@@ -1362,14 +1477,33 @@
           {
             "type": "save",
             "stat": "wis",
-            "fail": [],
+            "fail": [
+              {
+                "type": "ieffect",
+                "name": "Compelled Duel",
+                "duration": 10,
+                "effects": ""
+              }
+            ],
             "success": []
           }
         ]
       },
       {
+        "type": "target",
+        "target": "self",
+        "effects": [
+          {
+            "type": "ieffect",
+            "name": "Compelled Duel [Concentration]",
+            "duration": 10,
+            "effects": ""
+          }
+        ]
+      },
+      {
         "type": "text",
-        "text": "One creature that you can see within range must make a Wisdom saving throw.  On a failed save, the creature is drawn to you, compelled by your divine demand.  For the duration, it has disadvantage on attack rolls against creatures other than you, and must make a Wisdom saving throw each time it attempts to move to a space that is more than 30 feet away from you, if it succeeds on this saving throw, this spell doesn't restrict the target's movement for that turn."
+        "text": "One creature that you can see within range must make a Wisdom saving throw. On a failed save, the creature is drawn to you, compelled by your divine demand. For the duration, it has disadvantage on attack rolls against creatures other than you, and must make a Wisdom saving throw each time it attempts to move to a space that is more than 30 feet away from you, if it succeeds on this saving throw, this spell doesn't restrict the target's movement for that turn."
       }
     ]
   },
@@ -1387,14 +1521,33 @@
           {
             "type": "save",
             "stat": "wis",
-            "fail": [],
+            "fail": [
+              {
+                "type": "ieffect",
+                "name": "Compulsion - Charmed",
+                "duration": 10,
+                "effects": ""
+              }
+            ],
             "success": []
           }
         ]
       },
       {
+        "type": "target",
+        "target": "self",
+        "effects": [
+          {
+            "type": "ieffect",
+            "name": "Compulsion [Concentration]",
+            "duration": 10,
+            "effects": ""
+          }
+        ]
+      },
+      {
         "type": "text",
-        "text": "Creatures of your choice that you can see within range and that can hear you must make a Wisdom saving throw.  A target automatically succeeds on this saving throw if it can't be charmed.  On a failed save, a target is affected by this spell.\nAfter moving in this way, it can make another Wisdom saving throw to try to end the effect."
+        "text": "Creatures of your choice that you can see within range and that can hear you must make a Wisdom saving throw. A target automatically succeeds on this saving throw if it can't be charmed. On a failed save, a target is affected by this spell.\nAfter moving in this way, it can make another Wisdom saving throw to try to end the effect."
       }
     ]
   },
@@ -1438,17 +1591,70 @@
       },
       {
         "type": "text",
-        "text": "Each creature in a 60-foot cone must make a Constitution saving throw.  A creature takes 8d8 cold damage on a failed save, or half as much damage on a successful one."
+        "text": "Each creature in a 60-foot cone must make a Constitution saving throw. A creature takes 8d8 cold damage on a failed save, or half as much damage on a successful one.\n\nA creature killed by this spell becomes a frozen statue until it thaws."
       }
     ]
   },
   {
     "name": "Confusion",
-    "automation": null
+    "automation": [
+      {
+        "type": "target",
+        "target": "self",
+        "effects": [
+          {
+            "type": "ieffect",
+            "name": "Confusion [Concentration]",
+            "duration": 10,
+            "effects": ""
+          }
+        ]
+      },
+      {
+        "type": "target",
+        "target": "all",
+        "effects": [
+          {
+            "type": "save",
+            "stat": "wis",
+            "fail": [
+              {
+                "type": "ieffect",
+                "name": "Confusion",
+                "duration": 10,
+                "effects": ""
+              }
+            ],
+            "success": []
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": "Each creature in a 10-foot-radius sphere centered on a point you choose within range must succeed on a Wisdom saving throw when you cast this spell or be affected by it.\n\nAn affected target can't take reactions and must roll a d10 at the start of each of its turns to determine its behavior for that turn."
+      }
+    ]
   },
   {
     "name": "Conjure Animals",
-    "automation": null
+    "automation": [
+      {
+        "type": "target",
+        "target": "self",
+        "effects": [
+          {
+            "type": "ieffect",
+            "name": "Conjure Animals [Concentration]",
+            "duration": -1,
+            "effects": ""
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": "You summon fey spirits that take the form of beasts and appear in unoccupied spaces that you can see within range. "
+      }
+    ]
   },
   {
     "name": "Conjure Barrage",
@@ -1478,32 +1684,99 @@
           {
             "type": "roll",
             "dice": "3d8",
-            "name": "damage",
-            "higher": {}
+            "name": "damage"
           }
         ]
       },
       {
         "type": "text",
-        "text": "Each creature in a 60-foot cone must succeed on a Dexterity saving throw.  A creature takes 3d8 damage on a failed save, or half as much damage on a successful one.  The damage type is the same as that of the weapon or ammunition used as a component."
+        "text": "Each creature in a 60-foot cone must succeed on a Dexterity saving throw. A creature takes 3d8 damage on a failed save, or half as much damage on a successful one. The damage type is the same as that of the weapon or ammunition used as a component."
       }
     ]
   },
   {
     "name": "Conjure Celestial",
-    "automation": null
+    "automation": [
+      {
+        "type": "target",
+        "target": "self",
+        "effects": [
+          {
+            "type": "ieffect",
+            "name": "Conjure Celestial [Concentration]",
+            "duration": -1,
+            "effects": ""
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": "You summon a celestial of challenge rating 4 or lower, which appears in an unoccupied space that you can see within range. The celestial disappears when it drops to 0 hit points or when the spell ends."
+      }
+    ]
   },
   {
     "name": "Conjure Elemental",
-    "automation": null
+    "automation": [
+      {
+        "type": "target",
+        "target": "self",
+        "effects": [
+          {
+            "type": "ieffect",
+            "name": "Conjure Elemental [Concentration]",
+            "duration": -1,
+            "effects": ""
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": "You call forth an elemental servant. Choose an area of air, earth, fire, or water that fills a 10-foot cube within range. An elemental of challenge rating 5 or lower appropriate to the area you chose appears in an unoccupied space within 10 feet of it. For example, a fire elemental emerges from a bonfire, and an earth elemental rises up from the ground. The elemental disappears when it drops to 0 hit points or when the spell ends."
+      }
+    ]
   },
   {
     "name": "Conjure Fey",
-    "automation": null
+    "automation": [
+      {
+        "type": "target",
+        "target": "self",
+        "effects": [
+          {
+            "type": "ieffect",
+            "name": "Conjure Fey [Concentration]",
+            "duration": -1,
+            "effects": ""
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": "You summon a fey creature of challenge rating 6 or lower, or a fey spirit that takes the form of a beast of challenge rating 6 or lower. It appears in an unoccupied space that you can see within range. The fey creature disappears when it drops to 0 hit points or when the spell ends."
+      }
+    ]
   },
   {
     "name": "Conjure Minor Elementals",
-    "automation": null
+    "automation": [
+      {
+        "type": "target",
+        "target": "self",
+        "effects": [
+          {
+            "type": "ieffect",
+            "name": "Conjure Minor Elementals [Concentration]",
+            "duration": -1,
+            "effects": ""
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": "You summon elementals that appear in unoccupied spaces that you can see within range. An elemental summoned by this spell disappears when it drops to 0 hit points or when the spell ends."
+      }
+    ]
   },
   {
     "name": "Conjure Volley",
@@ -1533,28 +1806,100 @@
           {
             "type": "roll",
             "dice": "8d8",
-            "name": "damage",
-            "higher": {}
+            "name": "damage"
           }
         ]
       },
       {
         "type": "text",
-        "text": "20-foot-high cylinder centered on that point must make a Dexterity saving throw.  A creature takes 8d8 damage on a failed save, or half as much damage on a successful one.  The damage type is the same as that of the ammunition or weapon."
+        "text": "20-foot-high cylinder centered on that point must make a Dexterity saving throw. A creature takes 8d8 damage on a failed save, or half as much damage on a successful one. The damage type is the same as that of the ammunition or weapon."
       }
     ]
   },
   {
     "name": "Conjure Woodland Beings",
-    "automation": null
+    "automation": [
+      {
+        "type": "target",
+        "target": "self",
+        "effects": [
+          {
+            "type": "ieffect",
+            "name": "Conjure Woodland Beings [Concentration]",
+            "duration": -1,
+            "effects": ""
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": "You summon fey creatures that appear in unoccupied spaces that you can see within range. A summoned creature disappears when it drops to 0 hit points or when the spell ends."
+      }
+    ]
   },
   {
     "name": "Contact Other Plane",
-    "automation": null
+    "automation": [
+      {
+        "type": "target",
+        "target": "self",
+        "effects": [
+          {
+            "type": "save",
+            "stat": "int",
+            "fail": [
+              {
+                "type": "damage",
+                "damage": "6d6[psychic]"
+              },
+              {
+                "type": "ieffect",
+                "name": "Contact Other Plane - Insane",
+                "duration": -1,
+                "effects": "On a failure, you take 6d6 psychic damage and are insane until you finish a long rest. While insane, you can't take actions, can't understand what other creatures say, can't read, and speak only in gibberish. A greater restoration spell cast on you ends this effect."
+              }
+            ],
+            "success": [
+              {
+                "type": "text",
+                "text": "You can ask the entity up to five questions. You must ask your questions before the spell ends. The DM answers each question with one word. If a one-word answer would be misleading, the DM might instead offer a short phrase as an answer."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": "You mentally contact a demigod, the spirit of a long-dead sage, or some other mysterious entity from another plane. Contacting this extraplanar intelligence can strain or even break your mind. When you cast this spell, make a DC 15 Intelligence saving throw"
+      }
+    ]
   },
   {
     "name": "Contagion",
-    "automation": null
+    "automation": [
+      {
+        "type": "target",
+        "target": "each",
+        "effects": [
+          {
+            "type": "attack",
+            "hit": [
+              {
+                "type": "ieffect",
+                "name": "Contagion",
+                "duration": -1,
+                "effects": ""
+              }
+            ],
+            "miss": []
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": "Your touch inflicts disease. Make a melee spell attack against a creature within your reach. On a hit, you afflict the creature with a disease of your choice from any of the ones described below.\n\nAt the end of each of the target's turns, it must make a Constitution saving throw. After failing three of these saving throws, the disease's effects last for the duration, and the creature stops making these saves. After succeeding on three of these saving throws, the creature recovers from the disease, and the spell ends."
+      }
+    ]
   },
   {
     "name": "Contingency",
@@ -1566,7 +1911,24 @@
   },
   {
     "name": "Control Water",
-    "automation": null
+    "automation": [
+      {
+        "type": "target",
+        "target": "self",
+        "effects": [
+          {
+            "type": "ieffect",
+            "name": "Control Water [Concentration]",
+            "duration": -1,
+            "effects": ""
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": "Until the spell ends, you control any freestanding water inside an area you choose that is a cube up to 100 feet on a side. You can choose from any of the following effects when you cast this spell. As an action on your turn, you can repeat the same effect or choose a different one."
+      }
+    ]
   },
   {
     "name": "Control Weather",
@@ -1574,7 +1936,25 @@
   },
   {
     "name": "Cordon of Arrows",
-    "automation": null
+    "automation": [
+      {
+        "type": "target",
+        "target": "each",
+        "effects": [
+          {
+            "type": "save",
+            "stat": "dex",
+            "fail": [
+              {
+                "type": "damage",
+                "damage": "1d6[piercing]"
+              }
+            ],
+            "success": []
+          }
+        ]
+      }
+    ]
   },
   {
     "name": "Counterspell",
@@ -1606,20 +1986,64 @@
           {
             "type": "save",
             "stat": "wis",
-            "fail": [],
+            "fail": [
+              {
+                "type": "ieffect",
+                "name": "Crown of Madness - Charmed",
+                "duration": 10,
+                "effects": ""
+              }
+            ],
             "success": []
           }
         ]
       },
       {
+        "type": "target",
+        "target": "self",
+        "effects": [
+          {
+            "type": "ieffect",
+            "name": "Crown of Madness [Concentration]",
+            "duration": 10,
+            "effects": ""
+          }
+        ]
+      },
+      {
         "type": "text",
-        "text": "One humanoid of your choice that you can see within range must succeed on a Wisdom saving throw or become charmed by you for the duration.  While the target is charmed in this way, a twisted crown of jagged iron appears on its head, and a madness glows in its eyes.\nAlso, the target can make a Wisdom saving throw at the end of each of its turns.  On a success, the spell ends.."
+        "text": "One humanoid of your choice that you can see within range must succeed on a Wisdom saving throw or become charmed by you for the duration. While the target is charmed in this way, a twisted crown of jagged iron appears on its head, and a madness glows in its eyes.\n\nOn your subsequent turns, you must use your action to maintain control over the target, or the spell ends. Also, the target can make a Wisdom saving throw at the end of each of its turns. On a success, the spell ends."
       }
     ]
   },
   {
     "name": "Crusader's Mantle",
-    "automation": null
+    "automation": [
+      {
+        "type": "target",
+        "target": "self",
+        "effects": [
+          {
+            "type": "ieffect",
+            "name": "Crusader's Mantle [Concentration]",
+            "duration": 10,
+            "effects": ""
+          }
+        ]
+      },
+      {
+        "type": "target",
+        "target": "all",
+        "effects": [
+          {
+            "type": "ieffect",
+            "name": "Crusader's Mantle",
+            "duration": 10,
+            "effects": "-d 1d4[radiant]"
+          }
+        ]
+      }
+    ]
   },
   {
     "name": "Cure Wounds",
@@ -1646,7 +2070,7 @@
       },
       {
         "type": "text",
-        "text": ""
+        "text": "A creature you touch regains a number of hit points equal to 1d8 + your spellcasting ability modifier. This spell has no effect on undead or constructs."
       }
     ]
   },
@@ -1713,7 +2137,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature you choose within 30 feet of you must succeed on a Constitution saving throw or take 5d6 thunder damage, as well as 5d6 radiant or necrotic damage (your choice), and be knocked prone.  A creature that succeeds on its saving throw takes half as much damage and isn't knocked prone.."
+        "text": "Each creature you choose within 30 feet of you must succeed on a Constitution saving throw or take 5d6 thunder damage, as well as 5d6 radiant or necrotic damage (your choice), and be knocked prone. A creature that succeeds on its saving throw takes half as much damage and isn't knocked prone."
       }
     ]
   },
@@ -1746,7 +2170,7 @@
       },
       {
         "type": "text",
-        "text": "If you probe deeper, the target must make a Wisdom saving throw.  If it fails, you gain insight into its reasoning (if any), its emotional state, and something that looms large in its mind (such as something it worries over, loves, or hates).  If it succeeds, the spell ends."
+        "text": "If you probe deeper, the target must make a Wisdom saving throw. If it fails, you gain insight into its reasoning (if any), its emotional state, and something that looms large in its mind (such as something it worries over, loves, or hates). If it succeeds, the spell ends."
       }
     ]
   },
@@ -1848,7 +2272,7 @@
       },
       {
         "type": "text",
-        "text": "The target must make a Wisdom saving throw.  On a failed save, it takes 3d6 psychic damage and must immediately use its reaction, if available, to move as far as its speed allows away from you.  The creature doesn't move into obviously dangerous ground, such as a fire or a pit."
+        "text": "The target must make a Wisdom saving throw. On a failed save, it takes 3d6 psychic damage and must immediately use its reaction, if available, to move as far as its speed allows away from you. The creature doesn't move into obviously dangerous ground, such as a fire or a pit."
       }
     ]
   },
@@ -1877,7 +2301,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature that can hear you must make a Charisma saving throw.  On a failed save, a creature suffers an effect based on its current hit points."
+        "text": "Each creature that can hear you must make a Charisma saving throw. On a failed save, a creature suffers an effect based on its current hit points."
       }
     ]
   },
@@ -1898,7 +2322,7 @@
       },
       {
         "type": "text",
-        "text": "It must succeed on a Wisdom saving throw or be charmed by you for the duration.  If you or creatures that are friendly to you are fighting it, it has advantage on the saving throw."
+        "text": "It must succeed on a Wisdom saving throw or be charmed by you for the duration. If you or creatures that are friendly to you are fighting it, it has advantage on the saving throw."
       }
     ]
   },
@@ -1919,7 +2343,7 @@
       },
       {
         "type": "text",
-        "text": "It must succeed on a Wisdom saving throw or be charmed by you for the duration.  If you or creatures that are friendly to you are fighting it, it has advantage on the saving throw."
+        "text": "It must succeed on a Wisdom saving throw or be charmed by you for the duration. If you or creatures that are friendly to you are fighting it, it has advantage on the saving throw."
       }
     ]
   },
@@ -1940,7 +2364,7 @@
       },
       {
         "type": "text",
-        "text": "It must succeed on a Wisdom saving throw or be charmed by you for the duration.  If you or creatures that are friendly to you are fighting it, it has advantage on the saving throw."
+        "text": "It must succeed on a Wisdom saving throw or be charmed by you for the duration. If you or creatures that are friendly to you are fighting it, it has advantage on the saving throw."
       }
     ]
   },
@@ -1982,7 +2406,7 @@
       },
       {
         "type": "text",
-        "text": "Make a ranged spell attack against the target.  On a hit, the target takes 1d10 force damage."
+        "text": "Make a ranged spell attack against the target. On a hit, the target takes 1d10 force damage."
       }
     ]
   },
@@ -2040,7 +2464,7 @@
       },
       {
         "type": "text",
-        "text": "You weave a distracting string of words, causing creatures of your choice that you can see within range and that can hear you to make a Wisdom saving throw.  Any creature that can't be charmed succeeds on this saving throw automatically, and if you or your companions are fighting a creature, it has advantage on the save.  On a failed save, the target has disadvantage on Wisdom (Perception) checks made to perceive any creature other than you until the spell ends or until the target can no longer hear you."
+        "text": "You weave a distracting string of words, causing creatures of your choice that you can see within range and that can hear you to make a Wisdom saving throw. Any creature that can't be charmed succeeds on this saving throw automatically, and if you or your companions are fighting a creature, it has advantage on the save. On a failed save, the target has disadvantage on Wisdom (Perception) checks made to perceive any creature other than you until the spell ends or until the target can no longer hear you."
       }
     ]
   },
@@ -2103,7 +2527,7 @@
       },
       {
         "type": "text",
-        "text": "One creature of your choice within 60 feet of you that you can see must succeed on a Wisdom saving throw or be affected by one of the following effects of your choice for the duration.  On each of your turns until the spell ends, you can use your action to target another creature but can't target a creature again if it has succeeded on a saving throw against this casting of Eyebite.\nAt the end of each of its turns, it can make another Wisdom saving throw.  If it succeeds, the effect ends.."
+        "text": "One creature of your choice within 60 feet of you that you can see must succeed on a Wisdom saving throw or be affected by one of the following effects of your choice for the duration. On each of your turns until the spell ends, you can use your action to target another creature but can't target a creature again if it has succeeded on a saving throw against this casting of Eyebite.\nAt the end of each of its turns, it can make another Wisdom saving throw. If it succeeds, the effect ends."
       }
     ]
   },
@@ -2128,7 +2552,7 @@
       },
       {
         "type": "text",
-        "text": "Any creature in the area when the spell is cast is also outlined in light if it fails a Dexterity saving throw.  For the duration, objects and affected creatures shed dim light in a 10-foot radius."
+        "text": "Any creature in the area when the spell is cast is also outlined in light if it fails a Dexterity saving throw. For the duration, objects and affected creatures shed dim light in a 10-foot radius."
       }
     ]
   },
@@ -2153,7 +2577,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in a 30-foot cone must succeed on a Wisdom saving throw or drop whatever it is holding and become frightened for the duration.\nIf the creature ends its turn in a location where it doesn't have line of sight to you, the creature can make a Wisdom saving throw.  On a successful save, the spell ends for that creature.."
+        "text": "Each creature in a 30-foot cone must succeed on a Wisdom saving throw or drop whatever it is holding and become frightened for the duration.\nIf the creature ends its turn in a location where it doesn't have line of sight to you, the creature can make a Wisdom saving throw. On a successful save, the spell ends for that creature."
       }
     ]
   },
@@ -2220,7 +2644,7 @@
       },
       {
         "type": "text",
-        "text": "The target must make a Constitution saving throw.  It takes 7d8+30 necrotic damage on a failed save, or half as much damage on a successful one."
+        "text": "The target must make a Constitution saving throw. It takes 7d8+30 necrotic damage on a failed save, or half as much damage on a successful one."
       }
     ]
   },
@@ -2247,7 +2671,7 @@
       },
       {
         "type": "text",
-        "text": "Make a ranged spell attack against the target.  On a hit, the target takes 1d10 fire damage.  A flammable object hit by this spell ignites if it isn't being worn or carried."
+        "text": "Make a ranged spell attack against the target. On a hit, the target takes 1d10 fire damage. A flammable object hit by this spell ignites if it isn't being worn or carried."
       }
     ]
   },
@@ -2290,7 +2714,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in the area must make Dexterity saving throw.  It takes 7d10 fire damage on a failed save, or half as much damage on a successful one."
+        "text": "Each creature in the area must make Dexterity saving throw. It takes 7d10 fire damage on a failed save, or half as much damage on a successful one."
       }
     ]
   },
@@ -2336,7 +2760,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in a 20-foot radius must make a Dexterity saving throw.  A target takes 8d6 fire damage on a failed save, or half as much damage on a successful one."
+        "text": "Each creature in a 20-foot radius must make a Dexterity saving throw. A target takes 8d6 fire damage on a failed save, or half as much damage on a successful one."
       }
     ]
   },
@@ -2409,7 +2833,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in a 10-foot radius, 40-foot-high cylinder centered on a point within range must make a Dexterity saving throw.  A creature takes 4d6 fire damage and 4d6 radiant damage on a failed save, or half as much damage on a successful one."
+        "text": "Each creature in a 10-foot radius, 40-foot-high cylinder centered on a point within range must make a Dexterity saving throw. A creature takes 4d6 fire damage and 4d6 radiant damage on a failed save, or half as much damage on a successful one."
       }
     ]
   },
@@ -2456,7 +2880,7 @@
       },
       {
         "type": "text",
-        "text": "Any creature that ends its turn within 5 feet of the sphere must make a Dexterity saving throw.  The creature takes 2d6 fire damage on a failed save, or half as much damage on a successful one."
+        "text": "Any creature that ends its turn within 5 feet of the sphere must make a Dexterity saving throw. The creature takes 2d6 fire damage on a failed save, or half as much damage on a successful one."
       }
     ]
   },
@@ -2477,7 +2901,7 @@
       },
       {
         "type": "text",
-        "text": "If the targets body is made of flesh, the creature must make a Constitution saving throw.  On a failed save, it is restrained as its flesh begins to harden.  On a successful save, the creature isn't affected."
+        "text": "If the targets body is made of flesh, the creature must make a Constitution saving throw. On a failed save, it is restrained as its flesh begins to harden. On a successful save, the creature isn't affected."
       }
     ]
   },
@@ -2599,7 +3023,7 @@
       },
       {
         "type": "text",
-        "text": "A creature that enters the area or ends its turn there must also succeed on a Dexterity saving throw or fall prone.."
+        "text": "A creature that enters the area or ends its turn there must also succeed on a Dexterity saving throw or fall prone."
       }
     ]
   },
@@ -2689,7 +3113,7 @@
       },
       {
         "type": "text",
-        "text": "Make a ranged spell attack against the target.  On a hit, the target takes 4d6 radiant damage, and the next attack roll made against this target before the end of your next turn has advantage, thanks to the mystical dim light glittering on the target until then."
+        "text": "Make a ranged spell attack against the target. On a hit, the target takes 4d6 radiant damage, and the next attack roll made against this target before the end of your next turn has advantage, thanks to the mystical dim light glittering on the target until then."
       }
     ]
   },
@@ -2758,7 +3182,7 @@
       },
       {
         "type": "text",
-        "text": "In addition to the normal effect of the attack, the target of the attack and each creature within 5 feet of it must make a Dexterity saving throw.  A creature takes 1d10 piercing damage on a failed save, or half as much damage on a successful one."
+        "text": "In addition to the normal effect of the attack, the target of the attack and each creature within 5 feet of it must make a Dexterity saving throw. A creature takes 1d10 piercing damage on a failed save, or half as much damage on a successful one."
       }
     ]
   },
@@ -2805,7 +3229,7 @@
       },
       {
         "type": "text",
-        "text": "The target must make a Constitution saving throw.  On a failed save, it takes 14d6 necrotic damage, or half as much damage on a successful save.  The damage can't reduce the target's hit points below 1."
+        "text": "The target must make a Constitution saving throw. On a failed save, it takes 14d6 necrotic damage, or half as much damage on a successful save. The damage can't reduce the target's hit points below 1."
       }
     ]
   },
@@ -2914,7 +3338,7 @@
       },
       {
         "type": "text",
-        "text": "The creature must make a Dexterity saving throw.  It takes 2d10 fire damage on a failed save, or half as much damage on a successful one."
+        "text": "The creature must make a Dexterity saving throw. It takes 2d10 fire damage on a failed save, or half as much damage on a successful one."
       }
     ]
   },
@@ -2947,7 +3371,7 @@
       },
       {
         "type": "text",
-        "text": "The target must succeed on a Wisdom saving throw or be paralyzed for the duration.  This spell has no effect on undead.  At the end of each of its turns, the target can make another Wisdom saving throw.\nAt the end of each of its turns, the target can make another Wisdom saving throw.  On a success, the spell ends on the target."
+        "text": "The target must succeed on a Wisdom saving throw or be paralyzed for the duration. This spell has no effect on undead. At the end of each of its turns, the target can make another Wisdom saving throw.\nAt the end of each of its turns, the target can make another Wisdom saving throw. On a success, the spell ends on the target."
       }
     ]
   },
@@ -2968,7 +3392,7 @@
       },
       {
         "type": "text",
-        "text": "The target must succeed on a Wisdom saving throw or be paralyzed for the duration.  At the end of each of its turns, the target can make another Wisdom saving throw.  On a success, the spell ends on the target."
+        "text": "The target must succeed on a Wisdom saving throw or be paralyzed for the duration. At the end of each of its turns, the target can make another Wisdom saving throw. On a success, the spell ends on the target."
       }
     ]
   },
@@ -2989,7 +3413,7 @@
       },
       {
         "type": "text",
-        "text": "The attacker must succeed on a Constitution saving throw or be blinded until the spell ends.."
+        "text": "The attacker must succeed on a Constitution saving throw or be blinded until the spell ends."
       }
     ]
   },
@@ -3023,7 +3447,7 @@
       },
       {
         "type": "text",
-        "text": "Any creature that ends its turn in the area must succeed on a Dexterity saving throw or take 2d6 acid damage as milky, otherworldly tentacles rub against it.."
+        "text": "Any creature that ends its turn in the area must succeed on a Dexterity saving throw or take 2d6 acid damage as milky, otherworldly tentacles rub against it."
       }
     ]
   },
@@ -3048,7 +3472,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in the area who sees the pattern must make a Wisdom saving throw.  On a failed save, the creature becomes charmed for the duration.  While charmed by this spell, the creature is incapacitated and has a speed of 0."
+        "text": "Each creature in the area who sees the pattern must make a Wisdom saving throw. On a failed save, the creature becomes charmed for the duration. While charmed by this spell, the creature is incapacitated and has a speed of 0."
       }
     ]
   },
@@ -3093,7 +3517,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in the cylinder must make a Dexterity saving throw.  A creature takes 2d8 bludgeoning damage and 4d6 cold damage on a failed save, or half as much damage on a successful one."
+        "text": "Each creature in the cylinder must make a Dexterity saving throw. A creature takes 2d8 bludgeoning damage and 4d6 cold damage on a failed save, or half as much damage on a successful one."
       }
     ]
   },
@@ -3122,7 +3546,7 @@
       },
       {
         "type": "text",
-        "text": "The target must succeed on a Wisdom saving throw or be bound by the spell, if it succeeds, it is immune to this spell if you cast it again.  While affected by this spell, the creature doesn't need to breathe, eat, or drink, and it doesn't age.  Divination spells can't locate or perceive the target."
+        "text": "The target must succeed on a Wisdom saving throw or be bound by the spell, if it succeeds, it is immune to this spell if you cast it again. While affected by this spell, the creature doesn't need to breathe, eat, or drink, and it doesn't age. Divination spells can't locate or perceive the target."
       }
     ]
   },
@@ -3196,7 +3620,7 @@
       },
       {
         "type": "text",
-        "text": "Make a melee spell attack against a creature you can reach.  On a hit, the target takes 3d10 necrotic damage."
+        "text": "Make a melee spell attack against a creature you can reach. On a hit, the target takes 3d10 necrotic damage."
       }
     ]
   },
@@ -3360,7 +3784,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in the line must make a Dexterity saving throw.  A creature takes 8d6 lightning damage on a failed save, or half as much damage on a successful one."
+        "text": "Each creature in the line must make a Dexterity saving throw. A creature takes 8d6 lightning damage on a failed save, or half as much damage on a successful one."
       }
     ]
   },
@@ -3426,7 +3850,7 @@
       },
       {
         "type": "text",
-        "text": "The target must make a Charisma saving throw.  On a failure, your soul moves into the target's body, and the target's soul becomes trapped in the container.  On a success, the target resists your efforts to possess it, and you can't attempt to possess it again for 24 hours.\nIf the host body dies while you're in it, the creature dies, and you must make a Charisma saving throw against your own spellcasting DC.  On a success, you return to the container if it is within 100 feet of you.  Otherwise, you die."
+        "text": "The target must make a Charisma saving throw. On a failure, your soul moves into the target's body, and the target's soul becomes trapped in the container. On a success, the target resists your efforts to possess it, and you can't attempt to possess it again for 24 hours.\nIf the host body dies while you're in it, the creature dies, and you must make a Charisma saving throw against your own spellcasting DC. On a success, you return to the container if it is within 100 feet of you. Otherwise, you die."
       }
     ]
   },
@@ -3569,7 +3993,7 @@
       },
       {
         "type": "text",
-        "text": "Make a ranged spell attack against the target.  On a hit, the target takes 4d4 acid damage immediately and 2d4 acid damage at the end of its next turn.  On a miss, the arrow splashes the target with acid for half as much of the initial damage and no damage at the end of its next turn."
+        "text": "Make a ranged spell attack against the target. On a hit, the target takes 4d4 acid damage immediately and 2d4 acid damage at the end of its next turn. On a miss, the arrow splashes the target with acid for half as much of the initial damage and no damage at the end of its next turn."
       }
     ]
   },
@@ -3616,7 +4040,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in a 40-foot-radius sphere centered on each point you choose must make a Dexterity saving throw.  The sphere spreads around corners.  A creature takes 20d6 fire damage and 20d6 bludgeoning damage on a failed save, or half as much damage on a successful one."
+        "text": "Each creature in a 40-foot-radius sphere centered on each point you choose must make a Dexterity saving throw. The sphere spreads around corners. A creature takes 20d6 fire damage and 20d6 bludgeoning damage on a failed save, or half as much damage on a successful one."
       }
     ]
   },
@@ -3661,7 +4085,7 @@
       },
       {
         "type": "text",
-        "text": "One creature that you can see must make a Wisdom saving throw.  If you are fighting the creature, it has advantage on the saving throw.  On a failed save, the target becomes charmed by you for the duration."
+        "text": "One creature that you can see must make a Wisdom saving throw. If you are fighting the creature, it has advantage on the saving throw. On a failed save, the target becomes charmed by you for the duration."
       }
     ]
   },
@@ -3801,7 +4225,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature within the area must make a Constitution saving throw.  On a failed save, a creature takes 10d6 cold damage.  On successful save, it takes half as much damage."
+        "text": "Each creature within the area must make a Constitution saving throw. On a failed save, a creature takes 10d6 cold damage. On successful save, it takes half as much damage."
       }
     ]
   },
@@ -3822,7 +4246,7 @@
       },
       {
         "type": "text",
-        "text": "An unwilling creature must make a Dexterity saving throw.  On a failed save, the creature is enclosed for the duration."
+        "text": "An unwilling creature must make a Dexterity saving throw. On a failed save, the creature is enclosed for the duration."
       }
     ]
   },
@@ -3868,7 +4292,7 @@
       },
       {
         "type": "text",
-        "text": "The target must make an Intelligence saving throw.  On a failed save, you create a phantasmal object, creature, or other visible phenomenon of your choice that is no larger than a 10-foot cube and that is perceivable only to the target for the duration.  This spell has no effect on undead or constructs."
+        "text": "The target must make an Intelligence saving throw. On a failed save, you create a phantasmal object, creature, or other visible phenomenon of your choice that is no larger than a 10-foot cube and that is perceivable only to the target for the duration. This spell has no effect on undead or constructs."
       }
     ]
   },
@@ -3901,7 +4325,7 @@
       },
       {
         "type": "text",
-        "text": ") At the completion of the casting, the target must make a Charisma saving throw.  On a failed save, it is bound to serve you for the duration.  If the creature was summoned or created by another spell, that spell's duration is extended to match the duration of this spell."
+        "text": ") At the completion of the casting, the target must make a Charisma saving throw. On a failed save, it is bound to serve you for the duration. If the creature was summoned or created by another spell, that spell's duration is extended to match the duration of this spell."
       }
     ]
   },
@@ -3965,7 +4389,7 @@
       },
       {
         "type": "text",
-        "text": "An unwilling creature must make a Wisdom saving throw to avoid the effect.  A shapechanger automatically succeeds on this saving throw."
+        "text": "An unwilling creature must make a Wisdom saving throw to avoid the effect. A shapechanger automatically succeeds on this saving throw."
       }
     ]
   },
@@ -4044,7 +4468,7 @@
       },
       {
         "type": "text",
-        "text": "Make a ranged spell attack.  On a hit, the target takes 1d8 fire damage."
+        "text": "Make a ranged spell attack. On a hit, the target takes 1d8 fire damage."
       }
     ]
   },
@@ -4107,7 +4531,7 @@
       },
       {
         "type": "text",
-        "text": "Make a ranged spell attack against the target.  On a hit, it takes 1d8 cold damage, and its speed is reduced by 10 feet until the start of your next turn."
+        "text": "Make a ranged spell attack against the target. On a hit, it takes 1d8 cold damage, and its speed is reduced by 10 feet until the start of your next turn."
       }
     ]
   },
@@ -4211,7 +4635,7 @@
       },
       {
         "type": "text",
-        "text": "The target must succeed on a Dexterity saving throw or take 1d8 radiant damage.  The target gains no benefit from cover for this saving throw."
+        "text": "The target must succeed on a Dexterity saving throw or take 1d8 radiant damage. The target gains no benefit from cover for this saving throw."
       }
     ]
   },
@@ -4232,7 +4656,7 @@
       },
       {
         "type": "text",
-        "text": "Until the spell ends, any creature who targets the warded creature with an attack or a harmful spell must first make a Wisdom saving throw.  On a failed save, the creature must choose a new target or lose the attack or spell.  This spell doesn't protect the warded creature from area effects, such as the explosion of a fireball."
+        "text": "Until the spell ends, any creature who targets the warded creature with an attack or a harmful spell must first make a Wisdom saving throw. On a failed save, the creature must choose a new target or lose the attack or spell. This spell doesn't protect the warded creature from area effects, such as the explosion of a fireball."
       }
     ]
   },
@@ -4279,7 +4703,7 @@
       },
       {
         "type": "text",
-        "text": "The target must make a Wisdom saving throw, which is modified by how well you know the target and the sort of physical connection you have to it.  If a target knows you're casting this spell, it can fail the saving throw voluntarily if it wants to be observed."
+        "text": "The target must make a Wisdom saving throw, which is modified by how well you know the target and the sort of physical connection you have to it. If a target knows you're casting this spell, it can fail the saving throw voluntarily if it wants to be observed."
       }
     ]
   },
@@ -4367,7 +4791,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in a 10-foot-radius sphere centered on that point must make a Constitution saving throw.  A creature takes 3d8 thunder damage on a failed save, or half as much damage on a successful one.  A creature made of inorganic material such as stone, crystal, or metal has disadvantage on this saving throw."
+        "text": "Each creature in a 10-foot-radius sphere centered on that point must make a Constitution saving throw. A creature takes 3d8 thunder damage on a failed save, or half as much damage on a successful one. A creature made of inorganic material such as stone, crystal, or metal has disadvantage on this saving throw."
       }
     ]
   },
@@ -4406,7 +4830,7 @@
       },
       {
         "type": "text",
-        "text": "Make a melee spell attack against the target.  You have advantage on the attack roll if the target is wearing armor made of metal.  On a hit, the target takes 1d8 lightning damage, and it can't take reactions until the start of its next turn."
+        "text": "Make a melee spell attack against the target. You have advantage on the attack roll if the target is wearing armor made of metal. On a hit, the target takes 1d8 lightning damage, and it can't take reactions until the start of its next turn."
       }
     ]
   },
@@ -4500,7 +4924,7 @@
       },
       {
         "type": "text",
-        "text": "An affected creature's speed is halved in the area, and when the creature enters the area for the first time on a turn or starts its turn there, it must make a Wisdom saving throw.  On a failed save, the creature takes 3d8 radiant damage (if you are good or neutral) or 3d8 necrotic damage (if you are evil).  On a successful save, the creature takes half as much damage."
+        "text": "An affected creature's speed is halved in the area, and when the creature enters the area for the first time on a turn or starts its turn there, it must make a Wisdom saving throw. On a failed save, the creature takes 3d8 radiant damage (if you are good or neutral) or 3d8 necrotic damage (if you are evil). On a successful save, the creature takes half as much damage."
       }
     ]
   },
@@ -4534,7 +4958,7 @@
       },
       {
         "type": "text",
-        "text": "When you cast the spell, you can make a melee spell attack against a creature within 5 feet of the weapon.  On a hit, the target takes force damage equal to 1d8 + your spellcasting ability modifier."
+        "text": "When you cast the spell, you can make a melee spell attack against a creature within 5 feet of the weapon. On a hit, the target takes force damage equal to 1d8 + your spellcasting ability modifier."
       }
     ]
   },
@@ -4631,7 +5055,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in the line must make a Constitution saving throw.  On a failed save, a creature takes 6d8 radiant damage and is blinded until your next turn.  On a successful save, it takes half as much damage and isn't blinded by this spell."
+        "text": "Each creature in the line must make a Constitution saving throw. On a failed save, a creature takes 6d8 radiant damage and is blinded until your next turn. On a successful save, it takes half as much damage and isn't blinded by this spell."
       }
     ]
   },
@@ -4670,7 +5094,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in that light must make a Constitution saving throw.  On a failed save, a creature takes 12d6 radiant damage and is blinded for 1 minute.  On a successful save, it takes half as much damage and isn't blinded by this spell."
+        "text": "Each creature in that light must make a Constitution saving throw. On a failed save, a creature takes 12d6 radiant damage and is blinded for 1 minute. On a successful save, it takes half as much damage and isn't blinded by this spell."
       }
     ]
   },
@@ -4699,7 +5123,7 @@
       },
       {
         "type": "text",
-        "text": "The target must succeed on a Wisdom saving throw or fall prone, becoming incapacitated and unable to stand up for the duration.  A creature with an Intelligence score of 4 or less isn't affected."
+        "text": "The target must succeed on a Wisdom saving throw or fall prone, becoming incapacitated and unable to stand up for the duration. A creature with an Intelligence score of 4 or less isn't affected."
       }
     ]
   },
@@ -4750,7 +5174,7 @@
       },
       {
         "type": "text",
-        "text": "Make a melee spell attack against the target.  If the attack hits, the creature takes 1d6 piercing damage, and if the creature is Large or smaller, you pull the creature up to 10 feet closer to you."
+        "text": "Make a melee spell attack against the target. If the attack hits, the creature takes 1d6 piercing damage, and if the creature is Large or smaller, you pull the creature up to 10 feet closer to you."
       }
     ]
   },
@@ -4802,7 +5226,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in a 15-foot cube originating from you must make a Constitution saving throw.  On a failed save, a creature takes 2d8 thunder damage and is pushed 10 feet away from you.  On a successful save, the creature takes half as much damage and isn't pushed."
+        "text": "Each creature in a 15-foot cube originating from you must make a Constitution saving throw. On a failed save, a creature takes 2d8 thunder damage and is pushed 10 feet away from you. On a successful save, the creature takes half as much damage and isn't pushed."
       }
     ]
   },
@@ -4892,7 +5316,7 @@
       },
       {
         "type": "text",
-        "text": "Make a melee spell attack against a creature within your reach.  On a hit, the target takes 3d6 necrotic damage, and you regain hit points equal to half the amount of necrotic damage dealt.  Until the spell ends, you can make the attack again on each of your turns as an action."
+        "text": "Make a melee spell attack against a creature within your reach. On a hit, the target takes 3d6 necrotic damage, and you regain hit points equal to half the amount of necrotic damage dealt. Until the spell ends, you can make the attack again on each of your turns as an action."
       }
     ]
   },
@@ -5001,7 +5425,7 @@
       },
       {
         "type": "text",
-        "text": "If a creature would be surrounded on all sides by the wall (or the wall and another solid surface), that creature can make a Dexterity saving throw.  On a success, it can use its reaction to move up to its speed so that it is no longer enclosed by the wall."
+        "text": "If a creature would be surrounded on all sides by the wall (or the wall and another solid surface), that creature can make a Dexterity saving throw. On a success, it can use its reaction to move up to its speed so that it is no longer enclosed by the wall."
       }
     ]
   },
@@ -5044,7 +5468,7 @@
       },
       {
         "type": "text",
-        "text": "Furthermore, the first time a creature enters the wall on a turn or ends its turn there, the creature must make a Dexterity saving throw.  It takes 7d8 slashing damage on a failed save, or half as much on a successful save."
+        "text": "Furthermore, the first time a creature enters the wall on a turn or ends its turn there, the creature must make a Dexterity saving throw. It takes 7d8 slashing damage on a failed save, or half as much on a successful save."
       }
     ]
   },
@@ -5094,7 +5518,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in a 30-foot-radius sphere centered on a point of your choice within range must make a Wisdom saving throw.  On a failed save, a creature becomes frightened for the duration.  The illusion calls on the creature's deepest fears, manifesting its worst nightmares as an implacable threat.\nAt the end of each of the frightened creature's turns, it must succeed on a Wisdom saving throw or take 4d10 psychic damage.  On a successful save, the spell ends for that creature.."
+        "text": "Each creature in a 30-foot-radius sphere centered on a point of your choice within range must make a Wisdom saving throw. On a failed save, a creature becomes frightened for the duration. The illusion calls on the creature's deepest fears, manifesting its worst nightmares as an implacable threat.\nAt the end of each of the frightened creature's turns, it must succeed on a Wisdom saving throw or take 4d10 psychic damage. On a successful save, the spell ends for that creature."
       }
     ]
   },
@@ -5176,7 +5600,7 @@
       },
       {
         "type": "text",
-        "text": "Make a ranged spell attack against that creature.  On a hit, the target takes 1d12 lightning damage, and on each of your turns for the duration, you can use your action to deal 1d12 lightning damage to the target automatically.  The spell ends if you use your action to do anything else."
+        "text": "Make a ranged spell attack against that creature. On a hit, the target takes 1d12 lightning damage, and on each of your turns for the duration, you can use your action to deal 1d12 lightning damage to the target automatically. The spell ends if you use your action to do anything else."
       }
     ]
   },
@@ -5205,7 +5629,7 @@
       },
       {
         "type": "text",
-        "text": "Until the spell ends, a creature that enters the spell's area for the first time on a turn or starts its turn there must make a Charisma saving throw.  On a failed save, a creature can't speak a deliberate lie while in the radius.  You know whether each creature succeeds or fails on its saving throw."
+        "text": "Until the spell ends, a creature that enters the spell's area for the first time on a turn or starts its turn there must make a Charisma saving throw. On a failed save, a creature can't speak a deliberate lie while in the radius. You know whether each creature succeeds or fails on its saving throw."
       }
     ]
   },
@@ -5248,7 +5672,7 @@
       },
       {
         "type": "text",
-        "text": "The target must succeed on a Strength saving throw or be pulled up to 10 feet in a straight line toward you and then take 1d8 lightning damage if it is within 5 feet of you. \nThe spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).."
+        "text": "The target must succeed on a Strength saving throw or be pulled up to 10 feet in a straight line toward you and then take 1d8 lightning damage if it is within 5 feet of you. \nThe spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8)."
       }
     ]
   },
@@ -5283,7 +5707,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature within range, other than you, must succeed on a Dexterity saving throw or take 1d6 force damage. \nThe spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).."
+        "text": "Each creature within range, other than you, must succeed on a Dexterity saving throw or take 1d6 force damage. \nThe spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6)."
       }
     ]
   },
@@ -5328,7 +5752,7 @@
       },
       {
         "type": "text",
-        "text": "The target must make a successful Charisma saving throw or be compelled to answer your call.  Once the connection is established, the call is crystal clear and cannot be dropped until the conversation has ended or the spell\u2019s duration ends.  You can end the conversation at any time, but a target must succeed on a Charisma saving throw to end the conversation."
+        "text": "The target must make a successful Charisma saving throw or be compelled to answer your call. Once the connection is established, the call is crystal clear and cannot be dropped until the conversation has ended or the spell\u2019s duration ends. You can end the conversation at any time, but a target must succeed on a Charisma saving throw to end the conversation."
       }
     ]
   },
@@ -5365,7 +5789,7 @@
       },
       {
         "type": "text",
-        "text": "If an electronic device within range is used by a creature, that creature must succeed on a Constitution saving throw to prevent the device from being shut down.  While the spell remains active, no electronic device within range can be started or restarted.."
+        "text": "If an electronic device within range is used by a creature, that creature must succeed on a Constitution saving throw to prevent the device from being shut down. While the spell remains active, no electronic device within range can be started or restarted."
       }
     ]
   },
@@ -5500,7 +5924,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in that area must make a Constitution saving throw.  Constructs and undead aren't affected, and plants and water elementals make this saving throw with disadvantage.  A creature takes 12d8 necrotic damage on a failed save, or half as much damage on a successful one."
+        "text": "Each creature in that area must make a Constitution saving throw. Constructs and undead aren't affected, and plants and water elementals make this saving throw with disadvantage. A creature takes 12d8 necrotic damage on a failed save, or half as much damage on a successful one."
       }
     ]
   },
@@ -5551,7 +5975,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in the line must make a Dexterity saving throw.  A creature takes 3d8 fire damage on a failed save, or half as much damage on a successful one. \nAt Higher Levels: When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for each slot level above 2nd."
+        "text": "Each creature in the line must make a Dexterity saving throw. A creature takes 3d8 fire damage on a failed save, or half as much damage on a successful one. \nAt Higher Levels: When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for each slot level above 2nd."
       }
     ]
   },
@@ -5619,7 +6043,7 @@
       },
       {
         "type": "text",
-        "text": "If the object would strike a creature, that creature must make a Dexterity saving throw.  On a failed save, the object strikes the target and stops moving.  When the object strikes something, the object and what it strikes each take 3d8 bludgeoning damage."
+        "text": "If the object would strike a creature, that creature must make a Dexterity saving throw. On a failed save, the object strikes the target and stops moving. When the object strikes something, the object and what it strikes each take 3d8 bludgeoning damage."
       }
     ]
   },
@@ -5644,7 +6068,7 @@
       },
       {
         "type": "text",
-        "text": "The target must succeed on a Wisdom saving throw or become frightened of you until the spell ends.  The frightened target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success\nAt Higher Levels: When you cast this spell using a spell slot of 2nd level or higher, you can target one additional creature for each slot level above 1st.  The creatures must be within 30 feet of each other when you target them."
+        "text": "The target must succeed on a Wisdom saving throw or become frightened of you until the spell ends. The frightened target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success\nAt Higher Levels: When you cast this spell using a spell slot of 2nd level or higher, you can target one additional creature for each slot level above 1st. The creatures must be within 30 feet of each other when you target them."
       }
     ]
   },
@@ -5683,7 +6107,7 @@
       },
       {
         "type": "text",
-        "text": "Make a ranged spell attack against the target.  On a hit, the target takes 2d8 damage + 1d6 damage.  Choose one of the d8s."
+        "text": "Make a ranged spell attack against the target. On a hit, the target takes 2d8 damage + 1d6 damage. Choose one of the d8s."
       }
     ]
   },
@@ -5704,7 +6128,7 @@
       },
       {
         "type": "text",
-        "text": "It must make a Wisdom saving throw, and it does so with advantage if you or your companions are fighting it.  If it fails the saving throw, it is charmed by you until the  spell ends or until you or your companions do anything harmful to it.  The charmed creature is friendly to you."
+        "text": "It must make a Wisdom saving throw, and it does so with advantage if you or your companions are fighting it. If it fails the saving throw, it is charmed by you until the  spell ends or until you or your companions do anything harmful to it. The charmed creature is friendly to you."
       }
     ]
   },
@@ -5747,7 +6171,7 @@
       },
       {
         "type": "text",
-        "text": "Any creature in the bonfire's space when you cast the spell must succeed on a Dexterity saving throw or take 1d8 fire damage.  A creature must also make the saving throw when it enters the bonfire's space for the first time on a turn or ends its turn there. \nThe spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8)."
+        "text": "Any creature in the bonfire's space when you cast the spell must succeed on a Dexterity saving throw or take 1d8 fire damage. A creature must also make the saving throw when it enters the bonfire's space for the first time on a turn or ends its turn there. \nThe spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8)."
       }
     ]
   },
@@ -5861,7 +6285,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature other than you in that area must make a Dexterity saving throw.  On a failed save, a creature takes 1d6 bludgeoning damage and is knocked prone.  If the ground in that area is loose earth or stone, it becomes difficult terrain until cleared, with each 5-foot diameter portion requiring at least 1 minute to clear by hand."
+        "text": "Each creature other than you in that area must make a Dexterity saving throw. On a failed save, a creature takes 1d6 bludgeoning damage and is knocked prone. If the ground in that area is loose earth or stone, it becomes difficult terrain until cleared, with each 5-foot diameter portion requiring at least 1 minute to clear by hand."
       }
     ]
   },
@@ -5882,7 +6306,7 @@
       },
       {
         "type": "text",
-        "text": "The target must succeed on a Strength saving throw, or its flying speed (if any) is reduced to 0 feet for the spell's duration.  An airborne creature affected by this spell safely descends at 60 feet per round until it reaches the ground or the spell ends.."
+        "text": "The target must succeed on a Strength saving throw, or its flying speed (if any) is reduced to 0 feet for the spell's duration. An airborne creature affected by this spell safely descends at 60 feet per round until it reaches the ground or the spell ends."
       }
     ]
   },
@@ -5907,7 +6331,7 @@
       },
       {
         "type": "text",
-        "text": "You reach into the mind of one creature you can see and force it to make an Intelligence saving throw.  A creature automatically succeeds if it is immune to being frightened.  On a failed save, the target loses the ability to distinguish friend from foe, regarding all creatures it can see as enemies until the spell ends."
+        "text": "You reach into the mind of one creature you can see and force it to make an Intelligence saving throw. A creature automatically succeeds if it is immune to being frightened. On a failed save, the target loses the ability to distinguish friend from foe, regarding all creatures it can see as enemies until the spell ends."
       }
     ]
   },
@@ -5946,7 +6370,7 @@
       },
       {
         "type": "text",
-        "text": "The target must make a Dexterity saving throw.  On a successful save, the target takes 2d8 necrotic damage, and the spell ends.  On a failed save, the target takes 4d8 necrotic damage, and until the spell ends, you can use your action on each of your turns to automatically deal 4d8 necrotic damage to the target."
+        "text": "The target must make a Dexterity saving throw. On a successful save, the target takes 2d8 necrotic damage, and the spell ends. On a failed save, the target takes 4d8 necrotic damage, and until the spell ends, you can use your action on each of your turns to automatically deal 4d8 necrotic damage to the target."
       }
     ]
   },
@@ -5992,7 +6416,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in that area must make a Dexterity saving throw.  A creature takes 3d12 bludgeoning damage on a failed save, or half as much damage on a successful one.  Additionally, the ground in that area becomes difficult terrain until cleared."
+        "text": "Each creature in that area must make a Dexterity saving throw. A creature takes 3d12 bludgeoning damage on a failed save, or half as much damage on a successful one. Additionally, the ground in that area becomes difficult terrain until cleared."
       }
     ]
   },
@@ -6039,7 +6463,7 @@
       },
       {
         "type": "text",
-        "text": "The target must make a Constitution saving throw.  On a failed save, the target takes 1d6 cold damage, and it has disadvantage on the next weapon attack roll it makes before the end of its next turn. \nThe spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6)."
+        "text": "The target must make a Constitution saving throw. On a failed save, the target takes 1d6 cold damage, and it has disadvantage on the next weapon attack roll it makes before the end of its next turn. \nThe spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6)."
       }
     ]
   },
@@ -6064,7 +6488,7 @@
       },
       {
         "type": "text",
-        "text": "You seize the air and compel it to create one of the following effects at a point you can see within range:\n\u2022 One Medium or smaller creature that you choose must succeed on a Strength saving throw or be pushed up to 5 feet away from you. \n\u2022 You create a small blast of air capable of moving one object that is neither held nor carried and that weighs no more than 5 pounds.  The object is pushed up to 10 feet away from you."
+        "text": "You seize the air and compel it to create one of the following effects at a point you can see within range:\n\u2022 One Medium or smaller creature that you choose must succeed on a Strength saving throw or be pushed up to 5 feet away from you. \n\u2022 You create a small blast of air capable of moving one object that is neither held nor carried and that weighs no more than 5 pounds. The object is pushed up to 10 feet away from you."
       }
     ]
   },
@@ -6174,7 +6598,7 @@
       },
       {
         "type": "text",
-        "text": "The target must make a Dexterity saving throw.  It takes 8d6 fire damage on a failed save, or half as much damage on a successful one.  On a failed save, the target also burns for the spell's duration."
+        "text": "The target must make a Dexterity saving throw. It takes 8d6 fire damage on a failed save, or half as much damage on a successful one. On a failed save, the target also burns for the spell's duration."
       }
     ]
   },
@@ -6213,7 +6637,7 @@
       },
       {
         "type": "text",
-        "text": "The target must succeed on a Constitution saving throw, or it take 1d6 poison damage and moves 5 feet in a random direction if it can move and its speed is at least 5 feet.  Roll a d4 for the direction: 1, north; 2, south; 3, east; or 4, west.  This movement doesn't provoke opportunity attacks, and if the direction rolled is blocked, the target doesn't move\nThe spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6)."
+        "text": "The target must succeed on a Constitution saving throw, or it take 1d6 poison damage and moves 5 feet in a random direction if it can move and its speed is at least 5 feet. Roll a d4 for the direction: 1, north; 2, south; 3, east; or 4, west. This movement doesn't provoke opportunity attacks, and if the direction rolled is blocked, the target doesn't move\nThe spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6)."
       }
     ]
   },
@@ -6275,7 +6699,7 @@
       },
       {
         "type": "text",
-        "text": "Until the spell ends, that area is difficult terrain, and any creature that starts its turn there must succeed on a Strength saving throw or take 6d6 bludgeoning damage and be pulled 10 feet toward the center.."
+        "text": "Until the spell ends, that area is difficult terrain, and any creature that starts its turn there must succeed on a Strength saving throw or take 6d6 bludgeoning damage and be pulled 10 feet toward the center."
       }
     ]
   },
@@ -6302,7 +6726,7 @@
       },
       {
         "type": "text",
-        "text": "You or someone else can make a ranged spell attack with one of the pebbles by throwing it or hurling it with a sling.  If thrown, a pebble has a range of 60 feet.  If someone else attacks with the pebble, that attacker adds your spellcasting ability modifier, not the attacker's, to the attack roll."
+        "text": "You or someone else can make a ranged spell attack with one of the pebbles by throwing it or hurling it with a sling. If thrown, a pebble has a range of 60 feet. If someone else attacks with the pebble, that attacker adds your spellcasting ability modifier, not the attacker's, to the attack roll."
       }
     ]
   },
@@ -6323,7 +6747,7 @@
       },
       {
         "type": "text",
-        "text": "An unwilling target must succeed on a Wisdom saving throw to resist the transformation.  An unwilling shapechanger automatically succeeds on the save. \nEach target assumes a beast form of your choice, and you can choose the same form or a different ones for each target."
+        "text": "An unwilling target must succeed on a Wisdom saving throw to resist the transformation. An unwilling shapechanger automatically succeeds on the save. \nEach target assumes a beast form of your choice, and you can choose the same form or a different ones for each target."
       }
     ]
   },
@@ -6362,7 +6786,7 @@
       },
       {
         "type": "text",
-        "text": "The target must make a Strength saving throw.  On a failed save, the target takes 2d6 bludgeoning damage and is restrained for the spell's duration."
+        "text": "The target must make a Strength saving throw. On a failed save, the target takes 2d6 bludgeoning damage and is restrained for the spell's duration."
       }
     ]
   },
@@ -6401,7 +6825,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature within 5 feet of the point where the meteor explodes must make a Dexterity saving throw.  A creature takes 2d6 fire damage on a failed save, or half as much damage on a successful one."
+        "text": "Each creature within 5 feet of the point where the meteor explodes must make a Dexterity saving throw. A creature takes 2d6 fire damage on a failed save, or half as much damage on a successful one."
       }
     ]
   },
@@ -6456,7 +6880,7 @@
       },
       {
         "type": "text",
-        "text": "The target must make a Wisdom saving throw, taking 3d8 psychic damage on a failed save, or half as much damage on a successful one.  On a failed save, you also always know the target's location until the spell ends, but only while the two of you are on the same plane of existence.  While you have this knowledge, the target can't become hidden from you, and if it's invisible it gains no benefit from that condition against you."
+        "text": "The target must make a Wisdom saving throw, taking 3d8 psychic damage on a failed save, or half as much damage on a successful one. On a failed save, you also always know the target's location until the spell ends, but only while the two of you are on the same plane of existence. While you have this knowledge, the target can't become hidden from you, and if it's invisible it gains no benefit from that condition against you."
       }
     ]
   },
@@ -6499,7 +6923,7 @@
       },
       {
         "type": "text",
-        "text": "Unless the target is undead, it must make a Constitution saving throw, taking 5d12 necrotic damage on a failed save, or half as much damage on a successful one.  A target killed by this damage rises up as a zombie at the start of your next turn.  The zombie pursues whatever creature it can see that is closest to it."
+        "text": "Unless the target is undead, it must make a Constitution saving throw, taking 5d12 necrotic damage on a failed save, or half as much damage on a successful one. A target killed by this damage rises up as a zombie at the start of your next turn. The zombie pursues whatever creature it can see that is closest to it."
       }
     ]
   },
@@ -6520,7 +6944,7 @@
       },
       {
         "type": "text",
-        "text": "The target also has disadvantage on attack rolls, ability checks, and saving throws, other than Constitution saving throws.  Finally, if the target tries to cast a spell, it must first succeed on a Constitution saving throw, or the casting fails and the spell is wasted. \nA target suffering this pain can make a Constitution saving throw at the end of each of its turns.\nFinally, if the target tries to cast a spell, it must first succeed on a Constitution saving throw, or the casting fails and the spell is wasted. \nA target suffering this pain can make a Constitution saving throw at the end of each of its turns.  On a successful save, the pain ends."
+        "text": "The target also has disadvantage on attack rolls, ability checks, and saving throws, other than Constitution saving throws. Finally, if the target tries to cast a spell, it must first succeed on a Constitution saving throw, or the casting fails and the spell is wasted. \nA target suffering this pain can make a Constitution saving throw at the end of each of its turns.\nFinally, if the target tries to cast a spell, it must first succeed on a Constitution saving throw, or the casting fails and the spell is wasted. \nA target suffering this pain can make a Constitution saving throw at the end of each of its turns. On a successful save, the pain ends."
       }
     ]
   },
@@ -6547,7 +6971,7 @@
       },
       {
         "type": "text",
-        "text": "Make a melee spell attack against one creature within 5 feet of you.  On a hit, the target takes 1d10 acid damage.  After you make the attack, your teeth or fingernails return to normal."
+        "text": "Make a melee spell attack against one creature within 5 feet of you. On a hit, the target takes 1d10 acid damage. After you make the attack, your teeth or fingernails return to normal."
       }
     ]
   },
@@ -6590,7 +7014,7 @@
       },
       {
         "type": "text",
-        "text": "Each target must make an Intelligence saving throw.  On a failed save, a target takes 14d6 psychic damage and is stunned.  On a successful save, a target takes half as much damage and isn't stunned.\nA stunned target can make an Intelligence saving throw at the end of each of its turns.  On a successful save, the stunning effect ends.."
+        "text": "Each target must make an Intelligence saving throw. On a failed save, a target takes 14d6 psychic damage and is stunned. On a successful save, a target takes half as much damage and isn't stunned.\nA stunned target can make an Intelligence saving throw at the end of each of its turns. On a successful save, the stunning effect ends."
       }
     ]
   },
@@ -6615,7 +7039,7 @@
       },
       {
         "type": "text",
-        "text": "An unwilling creature must succeed on a Wisdom saving throw to resist this spell.  You teleport each affected target to an unoccupied space that you can see within 120 feet of you.  That space must be on the ground or on a floor."
+        "text": "An unwilling creature must succeed on a Wisdom saving throw to resist this spell. You teleport each affected target to an unoccupied space that you can see within 120 feet of you. That space must be on the ground or on a floor."
       }
     ]
   },
@@ -6660,7 +7084,7 @@
       },
       {
         "type": "text",
-        "text": "The triggering creature must succeed on a Dexterity saving throw or fall prone and be hoisted into the air until it hangs upside down 3 feet above the protected surface, where it is restrained. \nThe restrained creature can make a Dexterity saving throw with disadvantage at the end of each of its turns and ends the restrained effect on a success.  Alternatively, another creature that can reach the restrained creature can use an action to make an Intelligence (Arcana) check against your spell save DC.\nThe restrained creature can make a Dexterity saving throw with disadvantage at the end of each of its turns and ends the restrained effect on a success.  Alternatively, another creature that can reach the restrained creature can use an action to make an Intelligence (Arcana) check against your spell save DC.  On a success, the restrained effect also ends."
+        "text": "The triggering creature must succeed on a Dexterity saving throw or fall prone and be hoisted into the air until it hangs upside down 3 feet above the protected surface, where it is restrained. \nThe restrained creature can make a Dexterity saving throw with disadvantage at the end of each of its turns and ends the restrained effect on a success. Alternatively, another creature that can reach the restrained creature can use an action to make an Intelligence (Arcana) check against your spell save DC.\nThe restrained creature can make a Dexterity saving throw with disadvantage at the end of each of its turns and ends the restrained effect on a success. Alternatively, another creature that can reach the restrained creature can use an action to make an Intelligence (Arcana) check against your spell save DC. On a success, the restrained effect also ends."
       }
     ]
   },
@@ -6707,7 +7131,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in a 5-foot-radius sphere centered on that point must make a Dexterity saving throw.  A creature takes 3d6 cold damage on a failed save, or half as much damage on a successful one. \nAt Higher Levels: When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d6 for each slot level above 2nd."
+        "text": "Each creature in a 5-foot-radius sphere centered on that point must make a Dexterity saving throw. A creature takes 3d6 cold damage on a failed save, or half as much damage on a successful one. \nAt Higher Levels: When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d6 for each slot level above 2nd."
       }
     ]
   },
@@ -6737,7 +7161,7 @@
       },
       {
         "type": "text",
-        "text": "Make a melee spell attack against each target.  On a hit, a target takes 6d10 force damage. \nYou can then teleport to an unoccupied space you can see within 5 feet of one of the targets you hit or missed."
+        "text": "Make a melee spell attack against each target. On a hit, a target takes 6d10 force damage. \nYou can then teleport to an unoccupied space you can see within 5 feet of one of the targets you hit or missed."
       }
     ]
   },
@@ -6788,7 +7212,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in a 20-foot-radius sphere centered on that point must make an Intelligence saving throw.  A creature with an Intelligence score of 2 or lower can't be affected by this spell.  A target takes 8d6 psychic damage on a failed save, or half as much damage on a successful one.\nThe target can make an Intelligence saving throw at the end of each of its turns, ending the effect on itself on a success.."
+        "text": "Each creature in a 20-foot-radius sphere centered on that point must make an Intelligence saving throw. A creature with an Intelligence score of 2 or lower can't be affected by this spell. A target takes 8d6 psychic damage on a failed save, or half as much damage on a successful one.\nThe target can make an Intelligence saving throw at the end of each of its turns, ending the effect on itself on a success."
       }
     ]
   },
@@ -6842,7 +7266,7 @@
       },
       {
         "type": "text",
-        "text": "Immediately after you disappear, a thunderous boom sounds, and each creature within 10 feet of the space you left must make a Constitution saving throw, taking 3d10 thunder damage on a failed save, or half as much damage on a successful one.  The thunder can be heard from up to 300 feet away. \nYou can bring along objects as long as their weight doesn't exceed what you can carry."
+        "text": "Immediately after you disappear, a thunderous boom sounds, and each creature within 10 feet of the space you left must make a Constitution saving throw, taking 3d10 thunder damage on a failed save, or half as much damage on a successful one. The thunder can be heard from up to 300 feet away. \nYou can bring along objects as long as their weight doesn't exceed what you can carry."
       }
     ]
   },
@@ -6877,7 +7301,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature within range, other than you, must make a Constitution saving throw or take 1d6 thunder damage. \nThe spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).."
+        "text": "Each creature within range, other than you, must make a Constitution saving throw or take 1d6 thunder damage. \nThe spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6)."
       }
     ]
   },
@@ -6916,7 +7340,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature in that area must make a Dexterity saving throw.  On a failure, a creature takes 4d8 bludgeoning damage and is knocked prone.  On a success, a creature takes half as much damage and isn't knocked prone."
+        "text": "Each creature in that area must make a Dexterity saving throw. On a failure, a creature takes 4d8 bludgeoning damage and is knocked prone. On a success, a creature takes half as much damage and isn't knocked prone."
       }
     ]
   },
@@ -7008,7 +7432,7 @@
       },
       {
         "type": "text",
-        "text": "Each creature of your choice that you can see within 5 feet of you must succeed on a Constitution saving throw or take 1d6 radiant damage. \nThe spell\u2019s damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d8).."
+        "text": "Each creature of your choice that you can see within 5 feet of you must succeed on a Constitution saving throw or take 1d6 radiant damage. \nThe spell\u2019s damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d8)."
       }
     ]
   },


### PR DESCRIPTION
Calm Emotions, Chain Lightning, Charm Person, Chill Touch, Circle of Death, Circle of Power, Clairvoyance, Cloud of Daggers, Cloudkill, Command, Compelled Duel, Compulsion, Cone of Cold (Text edit), Confusion, Conjure Animals, Conjure Barrage (Text edit), Conjure Celestial, Conjure Fey, Conjure Minor Elementals, Conjure Volley (Text edit), Conjure Woodland Beings, Contact Other Plane, Contagion, Control Water, Cordon of Arrows, Crown of Madness, Crusader's Mantle, Cure Wounds,